### PR TITLE
Fix python39

### DIFF
--- a/pytest_capture_deprecatedwarnings/__init__.py
+++ b/pytest_capture_deprecatedwarnings/__init__.py
@@ -135,7 +135,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config=None):
     # instantiate abstract class 'Distribution' with abstract attributes
     # 'locate_file' and 'read_text'
     for distribution in importlib_metadata.Distribution().discover():  # type: ignore
-        if distribution.files:
+        if distribution.files and hasattr(distribution, "name"):
             for file in distribution.files:
                 _cached_path_to_package[
                     str(distribution.locate_file(file))

--- a/pytest_capture_deprecatedwarnings/__init__.py
+++ b/pytest_capture_deprecatedwarnings/__init__.py
@@ -19,7 +19,9 @@ default_formatwarning = warnings_recorder._module.formatwarning
 default_showwarning = warnings_recorder._module.showwarning
 
 
-def showwarning_with_traceback(message, category, filename, lineno, file=None, line=None):
+def showwarning_with_traceback(
+    message, category, filename, lineno, file=None, line=None
+):
     msg = warnings.WarningMessage(message, category, filename, lineno, file, line)
 
     msg.formatted_traceback = traceback.format_stack()
@@ -79,12 +81,14 @@ def pytest_runtest_call(item):
 
             module = warning.filename or "<unknown>"
             if module[-3:].lower() == ".py":
-                module = module[:-3] # XXX What about leading pathname?
+                module = module[:-3]  # XXX What about leading pathname?
 
-            if ((msg is None or msg.match(str(warning.message))) and
-                issubclass(warning.category, cat) and
-                (mod is None or mod.match(module)) and
-                (ln == 0 or warning.lineno == ln)):
+            if (
+                (msg is None or msg.match(str(warning.message)))
+                and issubclass(warning.category, cat)
+                and (mod is None or mod.match(module))
+                and (ln == 0 or warning.lineno == ln)
+            ):
                 break
         else:
             action = warnings.defaultaction
@@ -97,7 +101,12 @@ def pytest_runtest_call(item):
             continue
 
         warning.item = item
-        quadruplet = (warning.filename, warning.lineno, warning.category, str(warning.message))
+        quadruplet = (
+            warning.filename,
+            warning.lineno,
+            warning.category,
+            str(warning.message),
+        )
 
         if quadruplet in counted_warnings:
             counted_warnings[quadruplet].count += 1
@@ -113,7 +122,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config=None):
 
     def cut_path(path):
         if path.startswith(pwd):
-            path = path[len(pwd) + 1:]
+            path = path[len(pwd) + 1 :]
         if "/site-packages/" in path:  # tox install the package in general
             path = path.split("/site-packages/")[1]
         return path
@@ -128,14 +137,21 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config=None):
     for distribution in importlib_metadata.Distribution().discover():  # type: ignore
         if distribution.files:
             for file in distribution.files:
-                _cached_path_to_package[str(distribution.locate_file(file))] = distribution.name
+                _cached_path_to_package[
+                    str(distribution.locate_file(file))
+                ] = distribution.name
 
     yield
 
-    dependencies = {x.metadata["Name"].lower(): x.metadata["Version"] for x in importlib_metadata.distributions()}
+    dependencies = {
+        x.metadata["Name"].lower(): x.metadata["Version"]
+        for x in importlib_metadata.distributions()
+    }
 
     # try to grab tox env name because tox don't give it
-    for test in terminalreporter.stats.get("passed", []) + terminalreporter.stats.get("failed", []):
+    for test in terminalreporter.stats.get("passed", []) + terminalreporter.stats.get(
+        "failed", []
+    ):
         if ".tox/" in test.location[0]:
             tox_env_name = test.location[0].split(".tox/")[1].split("/")[0]
             output_file_name = "%s-deprecated-warnings.json" % tox_env_name
@@ -153,21 +169,42 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config=None):
         print("")
         print("Deprecated warnings summary:")
         print("============================")
-        for warning in sorted(counted_warnings.values(), key=lambda x: (x.filename, x.lineno)):
-            print("%s\n-> %s:%s %s('%s')" % (format_test_function_location(warning.item), cut_path(warning.filename), warning.lineno, warning.category.__name__, warning.message))
+        for warning in sorted(
+            counted_warnings.values(), key=lambda x: (x.filename, x.lineno)
+        ):
+            print(
+                "%s\n-> %s:%s %s('%s')"
+                % (
+                    format_test_function_location(warning.item),
+                    cut_path(warning.filename),
+                    warning.lineno,
+                    warning.category.__name__,
+                    warning.message,
+                )
+            )
 
         print("")
-        print("All DeprecationWarning errors can be found in the %s file." % output_file_name)
+        print(
+            "All DeprecationWarning errors can be found in the %s file."
+            % output_file_name
+        )
 
         warnings_as_json = []
 
         for warning in counted_warnings.values():
-            serialized_warning = {x: str(getattr(warning.message, x)) for x in dir(warning.message) if not x.startswith("__")}
+            serialized_warning = {
+                x: str(getattr(warning.message, x))
+                for x in dir(warning.message)
+                if not x.startswith("__")
+            }
 
             saved_traceback = warning.traceback[:]
 
             stack_item = warning.traceback[-1]
-            while stack_item.filename != warning.filename and stack_item.lineno != warning.lineno:
+            while (
+                stack_item.filename != warning.filename
+                and stack_item.lineno != warning.lineno
+            ):
                 warning.traceback.pop()
                 warning.formatted_traceback.pop()
                 if warning.traceback:
@@ -178,30 +215,36 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config=None):
 
             serialized_traceback = []
             for x in warning.traceback:
-                serialized_frame = {key: getattr(x, key) for key in dir(x) if not key.startswith("_")}
+                serialized_frame = {
+                    key: getattr(x, key) for key in dir(x) if not key.startswith("_")
+                }
                 if os.path.exists(serialized_frame["filename"]):
-                    serialized_frame["file_content"] = open(serialized_frame["filename"]).read()
+                    serialized_frame["file_content"] = open(
+                        serialized_frame["filename"]
+                    ).read()
                 else:
                     serialized_frame["file_content"] = None
                 serialized_frame["filename"] = cut_path(serialized_frame["filename"])
                 serialized_traceback.append(serialized_frame)
 
-            serialized_warning.update({
-                "count": warning.count,
-                "lineno": warning.lineno,
-                "category": warning.category.__name__,
-                "path": warning.filename,
-                "filename": cut_path(warning.filename),
-                "test_file": warning.item.location[0],
-                "test_lineno": warning.item.location[1],
-                "test_name": warning.item.location[2],
-                "file_content": open(warning.filename, "r").read(),
-                "dependencies": dependencies,
-                "outdated_package": _cached_path_to_package.get(warning.filename),
-                # "outdated_package_metadata": get_distribution_from_file_path(warning.filename).json,
-                "formatted_traceback": "".join(warning.formatted_traceback),
-                "traceback": serialized_traceback,
-            })
+            serialized_warning.update(
+                {
+                    "count": warning.count,
+                    "lineno": warning.lineno,
+                    "category": warning.category.__name__,
+                    "path": warning.filename,
+                    "filename": cut_path(warning.filename),
+                    "test_file": warning.item.location[0],
+                    "test_lineno": warning.item.location[1],
+                    "test_name": warning.item.location[2],
+                    "file_content": open(warning.filename, "r").read(),
+                    "dependencies": dependencies,
+                    "outdated_package": _cached_path_to_package.get(warning.filename),
+                    # "outdated_package_metadata": get_distribution_from_file_path(warning.filename).json,
+                    "formatted_traceback": "".join(warning.formatted_traceback),
+                    "traceback": serialized_traceback,
+                }
+            )
 
             if "with_traceback" in serialized_warning:
                 del serialized_warning["with_traceback"]


### PR DESCRIPTION
Since python 3.9, distribution could not have the `name` attribute. This patch check if the attribute exists or not to avoid error when this is not the case.

By the way, blackish code.